### PR TITLE
feat: replace php-fpm port by sock

### DIFF
--- a/nginx/common/block-wpadmin.conf
+++ b/nginx/common/block-wpadmin.conf
@@ -6,7 +6,7 @@ location /wp-admin {
     location /wp-admin/admin-ajax.php {
         allow all;
         
-        fastcgi_pass php:9000;
+        fastcgi_pass unix:/run/php-fpm/fpm-www.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
@@ -14,7 +14,7 @@ location /wp-admin {
     location /wp-admin/async-upload.php {
         allow all;
 
-        fastcgi_pass php:9000;
+        fastcgi_pass unix:/run/php-fpm/fpm-www.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }

--- a/nginx/common/php.conf
+++ b/nginx/common/php.conf
@@ -5,7 +5,7 @@ location / {
 location ~ \.php$ {
     try_files $uri =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass php:9000;
+    fastcgi_pass unix:/run/php-fpm/fpm-www.sock;
     fastcgi_index index.php;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/nginx/common/wpfc-php.conf
+++ b/nginx/common/wpfc-php.conf
@@ -34,7 +34,7 @@ location / {
 location ~ \.php$ {
     try_files $uri =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass php:9000;
+    fastcgi_pass unix:/run/php-fpm/fpm-www.sock;
     fastcgi_index index.php;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
Recently, a security issue was reported about the vulnerability of the exposed PHP-FPM port. Since PHP-FPM uses port 9000 and all the sites are on a shared network, it was possible to send requests from one container to another, creating potential security risks. To fix this, we plan to use an FPM socket instead of the port.

This PR replaces the PHP-FPM port with the FPM socket.