### PR TITLE
Disable TLS 1.0 and TLS 1.1

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -47,7 +47,7 @@ http {
     ssl_session_timeout 10m;
     ssl_prefer_server_ciphers on;
     ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
 
     log_format main '$proxy_add_x_forwarded_for - $remote_user [$time_local] "$request" '
                 '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Disable TLS 1.0 and TLS 1.1.
There are various problems with TLS 1.0. An attacker might create connection failures and exploit vulnerabilities like BEAST (Browser Exploit Against SSL/TLS) by using TLS 1.0. Also, Attackers can perform man-in-the-middle attacks and observe the encryption traffic between your website and its visitors. TLS 1.1 is vulnerable to poodle and beast attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Updated SSL protocols to only support `TLSv1.2`, enhancing overall security by removing outdated `TLSv1` and `TLSv1.1` support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->