### PR TITLE
Explicitly exclude weak and insecure ciphers and algorithms

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,7 +46,7 @@ http {
     ssl_session_cache shared:SSL:20m;
     ssl_session_timeout 10m;
     ssl_prefer_server_ciphers on;
-    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS";
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
     log_format main '$proxy_add_x_forwarded_for - $remote_user [$time_local] "$request" '


### PR DESCRIPTION
Update the `ssl_ciphers` configuration to explicitly exclude weak and insecure ciphers and algorithms. This change enhances the security of SSL/TLS connections by ensuring that only strong and secure ciphers are used.

What Each Exclusion Means:
- `!aNULL`: Excludes ciphers that do not authenticate the server (anonymous ciphers), which are vulnerable to man-in-the-middle attacks.
- `!eNULL`: Excludes ciphers that do not encrypt traffic (null ciphers), ensuring that all traffic is encrypted.
- `!LOW`: Excludes low-strength ciphers (less than 128-bit keys), which are susceptible to brute-force attacks.
- `!3DES`: Excludes the 3DES cipher, which is considered weak and is vulnerable to certain types of attacks.
- `!MD5`: Excludes ciphers that use the MD5 hash function, which is vulnerable to collision attacks.
- `!EXP`: Excludes export-grade ciphers (weak, limited to 40 or 56-bit keys), which were originally designed to comply with export restrictions but are now insecure.
- `!PSK`: Excludes Pre-Shared Key ciphers, which are less secure than modern alternatives.
- `!SRP`: Excludes Secure Remote Password protocol ciphers, which are not commonly used and may introduce unnecessary vulnerabilities.
- `!DSS`: Excludes ciphers that use the Digital Signature Standard, which is not as secure as modern algorithms like RSA or ECDSA.

This update ensures a higher level of security for our encrypted connections by avoiding known weak and vulnerable ciphers and algorithms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Updated SSL configuration to exclude specific ciphers for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->