### PR TITLE
feat: add Cache-Control headers for static and PHP files

### DIFF
--- a/nginx/common/locations.conf
+++ b/nginx/common/locations.conf
@@ -13,6 +13,7 @@ location = /robots.txt {
 # Cache static files
 location ~* \.(ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|css|rss|atom|js|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf|swf)$ {
     add_header "Access-Control-Allow-Origin" "*";
+    add_header Cache-Control "public, max-age=31536000";
     access_log off;
     log_not_found off;
     expires max;

--- a/nginx/common/php.conf
+++ b/nginx/common/php.conf
@@ -10,4 +10,5 @@ location ~ \.php$ {
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param PATH_INFO $fastcgi_path_info;
+    add_header Cache-Control "public, max-age=3600";
 }

--- a/nginx/common/wpfc-php.conf
+++ b/nginx/common/wpfc-php.conf
@@ -42,4 +42,5 @@ location ~ \.php$ {
     fastcgi_cache_bypass $skip_cache;
     fastcgi_no_cache $skip_cache;
     fastcgi_cache WORDPRESS;
+    add_header Cache-Control "public, max-age=3600";
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced caching headers for static files, allowing browsers to cache for up to one year.
	- Added caching headers for PHP files, enabling caching for one hour.

These enhancements improve the performance and efficiency of file delivery by optimizing caching strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->