### PR TITLE
feat: update acme challenge location configuration

### DIFF
--- a/nginx/common/locations.conf
+++ b/nginx/common/locations.conf
@@ -20,11 +20,13 @@ location ~* \.(ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|css|rss|atom|js|jpg|jpeg|gi
 }
 
 # Allow Letsencrypt HTTP challenge URL
-location ^~ /.well-known/acme-challenge {
+location ^~ /.well-known/acme-challenge/ {
     auth_basic off;
+    auth_request off;
     allow all;
-    default_type "text/plain";
-    alias /var/www/.letsencrypt;
+    root /usr/share/nginx/html;
+    try_files $uri =404;
+    break;
 }
 
 # Deny hidden files

--- a/nginx/common/locations.conf
+++ b/nginx/common/locations.conf
@@ -19,6 +19,13 @@ location ~* \.(ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|css|rss|atom|js|jpg|jpeg|gi
     expires max;
 }
 
+# Allow .well-known verification
+location ^~ /.well-known {
+    auth_basic off;
+    alias /var/www/html/public/.well-known;
+    limit_except GET { deny all; }
+}
+
 # Allow Letsencrypt HTTP challenge URL
 location ^~ /.well-known/acme-challenge/ {
     auth_basic off;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Introduced a new location block for handling `/.well-known` requests.
	- Updated Let's Encrypt challenge location to include a trailing slash.
	- Disabled authentication for the ACME challenge endpoint.
	- Modified root directory and file handling for the challenge location.
	- Added error handling for non-existent files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->