### PR TITLE
feat: increase PHP memory limit to 256M in memory.ini and ols.ini

### DIFF
--- a/php/memory.ini
+++ b/php/memory.ini
@@ -1,2 +1,2 @@
 ; Maximum amount of memory a script may consume
-memory_limit = 128M
+memory_limit = 256M

--- a/php/ols.ini
+++ b/php/ols.ini
@@ -1,5 +1,5 @@
 ; Maximum amount of memory a script may consume
-memory_limit = 128M
+memory_limit = 256M
 
 ; Whether to allow HTTP file uploads.
 file_uploads = On


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the available memory allocation for PHP processes from 128MB to 256MB, enhancing performance and stability during complex operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->