### PR TITLE
fix(cache control): remove unnecessary cache control header from php.conf

### DIFF
--- a/nginx/common/php.conf
+++ b/nginx/common/php.conf
@@ -10,5 +10,4 @@ location ~ \.php$ {
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param PATH_INFO $fastcgi_path_info;
-    add_header Cache-Control "public, max-age=3600";
 }


### PR DESCRIPTION
Remove the unnecessary cache control header from the php.conf file. The header is only required for FastCGI cache-enabled sites.

fixes: https://github.com/flywp/flywp-app/issues/1761